### PR TITLE
feat: tolerate dirty json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretty-json-log",
-  "version": "1.4.2",
+  "version": "1.4.1",
   "bin": {
     "pjl": "pjl.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretty-json-log",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "bin": {
     "pjl": "pjl.js"
   },
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --pretty",
     "lint": "eslint . --fix --ignore-path .gitignore",
-    "test": "node --test"
+    "test": "npm run build && node --test"
   },
   "repository": {
     "url": "https://github.com/blacha/pretty-json-log"

--- a/src/pretty/simple.ts
+++ b/src/pretty/simple.ts
@@ -11,6 +11,8 @@ function getLogStatus(level: number): string {
   return c.bgRed('FATAL');
 }
 
+type LogObject = Record<string, unknown>;
+
 export const PrettySimplePino = {
   Ignore: new Set<string>([
     // pino formats
@@ -22,7 +24,7 @@ export const PrettySimplePino = {
     'name',
     'msg',
   ]),
-  formatObject(obj: Record<string, any>, prefix = ''): string[] {
+  formatObject(obj: LogObject, prefix = ''): string[] {
     const kvs = [];
     for (const key of Object.keys(obj)) {
       if (PrettySimplePino.Ignore.has(key)) continue;
@@ -35,9 +37,9 @@ export const PrettySimplePino = {
       if (typeofValue === 'number') {
         output = c.yellow(String(value));
       } else if (typeofValue === 'string') {
-        output = c.green(value);
+        output = c.green(value as string);
       } else if (typeofValue === 'object') {
-        const subOutput = this.formatObject(value, prefix);
+        const subOutput = this.formatObject(value as LogObject, prefix);
         if (subOutput.length > 0) {
           output = `{ ${subOutput.join(' ')} }`;
         }

--- a/src/transform.test.ts
+++ b/src/transform.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { tryGetJson } from './transform.js';
+
+describe('transform', () => {
+  describe('tryGetJson', () => {
+    it('returns null for invalid JSON', () => {
+      assert.strictEqual(tryGetJson(''), null);
+      assert.strictEqual(tryGetJson('foo'), null);
+      assert.strictEqual(tryGetJson('{"foo":'), null);
+      assert.strictEqual(tryGetJson('2024-01-01T19:53:58 {"foo":'), null);
+      assert.strictEqual(tryGetJson('2024-01-01T19:53:58 {"foo": "bar"}}'), null);
+    });
+
+    it('returns the parsed JSON', () => {
+      assert.deepStrictEqual(tryGetJson('{}'), {});
+      assert.deepStrictEqual(tryGetJson('{"foo": "bar"}'), { foo: 'bar' });
+      assert.deepStrictEqual(tryGetJson('2024-01-01T19:53:58 {"foo": "bar"}'), { foo: 'bar' });
+      assert.deepStrictEqual(tryGetJson('2024-01-01T19:53:58 {"foo": "bar"} garbage'), { foo: 'bar' });
+    });
+  });
+});

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -4,9 +4,15 @@ import { StringDecoder } from 'string_decoder';
 import { LogMessage, LogSkipLine } from './msg.js';
 import { PrettySimple } from './pretty/simple.js';
 
-function tryGetJson(data: string): null | Record<string, unknown> {
+export function tryGetJson(data: string): null | Record<string, unknown> {
+  const jsonStart = data.indexOf('{');
+  if (jsonStart === -1) return null;
+
+  const jsonEnd = data.lastIndexOf('}');
+  if (jsonEnd === -1) return null;
+
   try {
-    return JSON.parse(data);
+    return JSON.parse(data.slice(jsonStart, jsonEnd + 1));
   } catch {
     return null;
   }


### PR DESCRIPTION
When you use the `aws logs tail` command, it outputs non-JSON along with the JSON log entries. For example:

```bash
2024-01-01T19:52:19 {"level":20,"time":1704138739937,"pid":8,"hostname":"169.254.43.189","source":"search/src/lib/typesense.ts","msg":"found 20 records not in index"}
```

This change allows piping this type of output and having pjl still be able to parse the log entry. In theory, we could output the extraneous non-JSON data to stdout, but I don't personally need that, so I didn't implement it.

FYI, I use pino to output JSON log entries from an AWS Lambda function.